### PR TITLE
Removed unnecessary keyword

### DIFF
--- a/client.go
+++ b/client.go
@@ -8,7 +8,7 @@ import (
 
 const PingRate time.Duration = time.Second * 10
 
-var ErrAllNodesDown error = errors.New("all nodes appear to be down")
+var ErrAllNodesDown = errors.New("all nodes appear to be down")
 
 type Client struct {
 	cluster  chan *Session


### PR DESCRIPTION
fun fact: `log.Print(err.Error())` on line 48, `.Error()` can be removed, it reduces allocations by one but increases execution time of the `log.Print()` function by about 30%, i didnt touch it as I'd rather ye would decide which ye prefer ^^